### PR TITLE
[FEAR] FileUpload 컴포넌트, 스토리북

### DIFF
--- a/src/shared/ui/FileUpload/FileUpload.stories.tsx
+++ b/src/shared/ui/FileUpload/FileUpload.stories.tsx
@@ -1,0 +1,91 @@
+import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { FileUpload, FileUploadProps } from './FileUpload';
+
+import { Flex } from '../Flex';
+import { IconButton } from '../IconButton';
+import { Caption1 } from '../Typography';
+
+const meta = {
+  title: 'components/FileUpload',
+  component: FileUpload,
+  tags: ['autodocs'],
+} satisfies Meta<typeof FileUpload>;
+
+export default meta;
+
+export type Story = StoryObj<FileUploadProps>;
+export const Single: Story = {
+  args: {
+    mode: 'single',
+    placeholder: '파일을 업로드해주세요',
+  },
+  render: (args) => {
+    const [file, setFile] = useState<File | null>(null);
+
+    const handleFileUpload = (event: React.ChangeEvent<HTMLInputElement>) => {
+      const selectedFile = event.target.files?.[0] ?? null;
+      setFile(selectedFile);
+      event.target.value = '';
+    };
+
+    const resetFile = () => {
+      setFile(null);
+    };
+
+    return (
+      <Flex dir="col" gap={4}>
+        <FileUpload onChange={handleFileUpload} {...args} />
+        <Flex>
+          {file && (
+            <Flex alignItems="center" gap={2} className="h-auto w-full">
+              <Caption1 weight="medium">{file.name}</Caption1>
+              <IconButton iconName="close" size={15} onClick={resetFile} />
+            </Flex>
+          )}
+        </Flex>
+      </Flex>
+    );
+  },
+};
+
+export const Multiple: Story = {
+  args: {
+    mode: 'multiple',
+    placeholder: '파일 여러개를 선택해주세요',
+  },
+
+  render: (args) => {
+    const [files, setFiles] = useState<File[]>([]);
+
+    const handleFileUpload = (event: React.ChangeEvent<HTMLInputElement>) => {
+      const selectedFiles = Array.from(event.target.files || []);
+      setFiles((prevFiles) => [...prevFiles, ...selectedFiles]);
+      event.target.value = '';
+    };
+
+    const resetFile = (removeFile: File) => {
+      setFiles((prevFiles) => prevFiles.filter((file) => file !== removeFile));
+    };
+
+    return (
+      <Flex dir="col" gap={4}>
+        <FileUpload max={5} onChange={handleFileUpload} {...args} />
+        <Flex dir="col" gap={2}>
+          {files.map((file, index) => (
+            <Flex
+              alignItems="center"
+              gap={2}
+              className="h-auto w-full"
+              key={`${file.name}-${index}`}
+            >
+              <Caption1 weight="medium">{file.name}</Caption1>
+              <IconButton iconName="close" size={15} onClick={() => resetFile(file)} />
+            </Flex>
+          ))}
+        </Flex>
+      </Flex>
+    );
+  },
+};

--- a/src/shared/ui/FileUpload/FileUpload.stories.tsx
+++ b/src/shared/ui/FileUpload/FileUpload.stories.tsx
@@ -21,6 +21,16 @@ export const Single: Story = {
     mode: 'single',
     placeholder: '파일을 업로드해주세요',
   },
+  argTypes: {
+    mode: {
+      control: false,
+      options: ['single', 'multiple'],
+      table: {
+        type: { summary: 'single | multiple' },
+        defaultValue: { summary: 'single' },
+      },
+    },
+  },
   render: (args) => {
     const [file, setFile] = useState<File | null>(null);
 
@@ -36,7 +46,7 @@ export const Single: Story = {
 
     return (
       <Flex dir="col" gap={4}>
-        <FileUpload onChange={handleFileUpload} {...args} />
+        <FileUpload {...args} onChange={handleFileUpload} />
         <Flex>
           {file && (
             <Flex alignItems="center" gap={2} className="h-auto w-full">
@@ -71,7 +81,7 @@ export const Multiple: Story = {
 
     return (
       <Flex dir="col" gap={4}>
-        <FileUpload max={5} onChange={handleFileUpload} {...args} />
+        <FileUpload onChange={handleFileUpload} {...args} />
         <Flex dir="col" gap={2}>
           {files.map((file, index) => (
             <Flex

--- a/src/shared/ui/FileUpload/FileUpload.tsx
+++ b/src/shared/ui/FileUpload/FileUpload.tsx
@@ -27,11 +27,11 @@ export function FileUpload({ mode, ...props }: FileUploadProps) {
         </Body3>
       </Flex>
       <input
-        className="hidden"
         id={inputId}
         name="uploadFile"
         type="file"
         multiple={mode === 'multiple'}
+        className="hidden"
         {...props}
       />
     </label>

--- a/src/shared/ui/FileUpload/FileUpload.tsx
+++ b/src/shared/ui/FileUpload/FileUpload.tsx
@@ -1,0 +1,39 @@
+import { ComponentProps, useId } from 'react';
+
+import { Flex } from '../Flex';
+import { Icon } from '../Icon';
+import { Body3 } from '../Typography';
+
+export type FileUploadProps = {
+  /**
+   * The mode of the file upload.
+   */
+  mode: 'single' | 'multiple';
+} & ComponentProps<'input'>;
+
+export function FileUpload({ mode, ...props }: FileUploadProps) {
+  const inputId = useId();
+
+  return (
+    <label
+      className="focus-within:bg-primary-50 block w-full cursor-pointer rounded-xl border border-gray-200 bg-gray-50 px-4 py-3 transition-colors hover:bg-gray-100 md:py-3.5"
+      htmlFor={inputId}
+    >
+      <Flex alignItems="center">
+        <Icon name="file" size={25} color="gray" />
+        <Body3 className="text-gray-400" weight="medium">
+          {props.placeholder ||
+            (mode === 'single' ? '파일을 업로드해주세요' : '파일 여러개를 선택해주세요')}
+        </Body3>
+      </Flex>
+      <input
+        className="hidden"
+        id={inputId}
+        name="uploadFile"
+        type="file"
+        multiple={mode === 'multiple'}
+        {...props}
+      />
+    </label>
+  );
+}

--- a/src/shared/ui/FileUpload/FileUpload.tsx
+++ b/src/shared/ui/FileUpload/FileUpload.tsx
@@ -6,13 +6,18 @@ import { Body3 } from '../Typography';
 
 export type FileUploadProps = {
   /**
+   * The id of the file input.
+   */
+  id?: string;
+  /**
    * The mode of the file upload.
    */
   mode: 'single' | 'multiple';
-} & ComponentProps<'input'>;
+} & Omit<ComponentProps<'input'>, 'id' | 'multiple'>;
 
-export function FileUpload({ mode, ...props }: FileUploadProps) {
-  const inputId = useId();
+export function FileUpload({ id, mode, ...props }: FileUploadProps) {
+  const generatedId = useId();
+  const inputId = id || generatedId;
 
   return (
     <label

--- a/src/shared/ui/FileUpload/index.ts
+++ b/src/shared/ui/FileUpload/index.ts
@@ -1,0 +1,1 @@
+export { FileUpload } from './FileUpload';

--- a/src/shared/ui/Input/Input.tsx
+++ b/src/shared/ui/Input/Input.tsx
@@ -12,10 +12,10 @@ type InputProps = {
 
 export function Input({ value, onClickReset, ...props }: InputProps) {
   return (
-    <Flex gap="8px" alignItems="center" className="relative w-full">
+    <Flex gap={8} alignItems="center" className="relative w-full">
       <input
         value={value}
-        className="focus:bg-primary-50 w-full rounded-xl border border-none bg-gray-50 px-4 py-3 outline-1 outline-gray-200 md:py-3.5"
+        className="focus:bg-primary-50 w-full rounded-xl border-none bg-gray-50 px-4 py-3 outline-1 outline-gray-200 md:py-3.5"
         {...props}
       />
       {value && (

--- a/src/shared/ui/assets/file.svg
+++ b/src/shared/ui/assets/file.svg
@@ -1,0 +1,5 @@
+<svg width="24" height="25" viewBox="0 0 24 25" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M6.4668 5H13.709C13.9521 5 14.1855 5.09669 14.3574 5.26855L18.1816 9.0918C18.3535 9.26368 18.4502 9.49716 18.4502 9.74023V18.583C18.4502 19.0892 18.0394 19.5 17.5332 19.5H6.4668C5.96054 19.5 5.5498 19.0893 5.5498 18.583V5.91699C5.5498 5.41073 5.96054 5 6.4668 5Z" stroke="#6B7280" stroke-width="1.5"/>
+<path d="M12 10.25V15.0609" stroke="#6B7280" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M14.4053 12.6562L9.59434 12.6563" stroke="#6B7280" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/shared/ui/assets/index.tsx
+++ b/src/shared/ui/assets/index.tsx
@@ -7,6 +7,7 @@ import Check from './check.svg';
 import Close from './close.svg';
 import DownLoad from './download.svg';
 import Etc from './etc.svg';
+import File from './file.svg';
 import Insta from './instagram.svg';
 import List from './list.svg';
 import Loading from './loading.svg';
@@ -27,6 +28,7 @@ export const Icons = {
   close: Close,
   download: DownLoad,
   etc: Etc,
+  file: File,
   list: List,
   navbarArrow: NavbarArrow,
   new: New,


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FEAT] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BUGFIX] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [REFACTOR] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [CHORE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [TEST] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [PERFORMANCE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [SET] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [DOCS] 작업_내용을_한_줄로_요약해서_작성 -->

## 🔥 연관 이슈

- #46

## 🚀 작업 내용

- 파일 업로드 컴포넌트를 구현했습니다.
  - 단일/다중 파일 업로드 방식을 props로 제어할 수 있도록 구현했습니다. 
- 동일한 페이지 내에서 2개 이상의 업로드 영역을 구분하기 위해 useId를 사용했습니다.
- FileUpload 컴포넌트와 업로드된 파일을 표시하는 리스트는 책임이 다르다고 판단하여 분리했으며, 리스트 UI는 포함하지 않았습니다.
- 스토리북에서는 사용 예시를 보여주기 위해 state를 선언하고, 핸들러 함수를 노출했습니다.

![Aug-25-2025 15-18-11](https://github.com/user-attachments/assets/b09431b0-d1a3-456c-8eec-d5fdb132edfe)

## 고민한 내용 🧐

- 사용자가 중복으로 같은 사진을 올리는 경우에 대해 생각을 해봤는데, 요 경우는 사용처에서 핸들링해줘야 될 것 같다고 생각했습니다! 추후 논의해보면 좋을 것 같아용


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 파일 업로드 컴포넌트 추가: 단일/다중 모드 지원, 플레이스홀더 및 아이콘 포함한 업로드 UI 제공, id 속성으로 입력 연결.

- 문서
  - Storybook 스토리 추가: Single/Multiple 예제(파일 선택, 재선택을 위한 리셋, 개별 파일 제거 등)로 사용법 데모.

- 스타일
  - 입력 컴포넌트 간격 및 테두리 스타일 조정(간격 값 변경 및 border 제거).

- 아이콘
  - 새로운 "file" 아이콘 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->