### PR TITLE
[FEAT] Tooltip 컴포넌트, 스토리북

### DIFF
--- a/src/shared/constants/motion.ts
+++ b/src/shared/constants/motion.ts
@@ -17,3 +17,60 @@ export const SLIDE_IN_ANIMATION = {
   exit: { translateX: '100%' },
   transition: { type: 'tween', damping: 50 },
 };
+
+export const TOOLTIP_MOTION = {
+  SPRING: {
+    initial: { opacity: 0, scale: 0.6, y: 15 },
+    animate: {
+      opacity: 1,
+      scale: 1,
+      y: 0,
+      transition: {
+        type: 'spring',
+        stiffness: 300,
+        damping: 20,
+        mass: 0.8,
+      },
+    },
+    exit: {
+      opacity: 0,
+      scale: 0.6,
+      y: 15,
+      transition: { duration: 0.1 },
+    },
+  },
+  POP: {
+    initial: { opacity: 0, scale: 0.3 },
+    animate: {
+      opacity: 1,
+      scale: 1,
+      transition: {
+        type: 'spring',
+        stiffness: 500,
+        damping: 15,
+        mass: 0.5,
+      },
+    },
+    exit: {
+      opacity: 0,
+      scale: 0.3,
+      transition: { duration: 0.08 },
+    },
+  },
+  SMOOTH: {
+    initial: { opacity: 0, y: 10 },
+    animate: {
+      opacity: 1,
+      y: 0,
+      transition: {
+        duration: 0.2,
+        ease: 'easeOut',
+      },
+    },
+    exit: {
+      opacity: 0,
+      y: 10,
+      transition: { duration: 0.15, ease: 'easeIn' },
+    },
+  },
+};

--- a/src/shared/hooks/useFloating.ts
+++ b/src/shared/hooks/useFloating.ts
@@ -1,0 +1,25 @@
+import { useEffect, useRef, useState } from 'react';
+
+export const useFloating = () => {
+  const [open, setOpen] = useState(false);
+  const [position, setPosition] = useState<{ top: number; left: number } | null>(null);
+  const ref = useRef<HTMLDivElement>(null);
+
+  const show = () => setOpen(true);
+  const hide = () => setOpen(false);
+
+  useEffect(() => {
+    if (ref.current && open) {
+      const rect = ref.current.getBoundingClientRect();
+      setPosition({ top: rect.top, left: rect.left + rect.width / 2 });
+    }
+  }, [open]);
+
+  return {
+    open,
+    ref,
+    show,
+    hide,
+    position,
+  };
+};

--- a/src/shared/hooks/useTooltip.ts
+++ b/src/shared/hooks/useTooltip.ts
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 
-export const useFloating = () => {
+export const useTooltip = () => {
   const [open, setOpen] = useState(false);
   const [position, setPosition] = useState<{ top: number; left: number } | null>(null);
   const ref = useRef<HTMLDivElement>(null);

--- a/src/shared/ui/Tooltip/Tooltip.stories.tsx
+++ b/src/shared/ui/Tooltip/Tooltip.stories.tsx
@@ -1,0 +1,51 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { tooltipColorMap } from './tooltipColorMap';
+
+import { Tooltip } from '.';
+import { Flex } from '../Flex';
+import { Icon } from '../Icon';
+
+const meta = {
+  title: 'components/Tooltip',
+  component: Tooltip,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Tooltip 컴포넌트는 사용자가 요소에 마우스를 올리거나 포커스를 맞출 때 추가 정보를 표시하는 데 사용됩니다.',
+      },
+    },
+  },
+} satisfies Meta<typeof Tooltip>;
+
+export default meta;
+type Story = StoryObj<typeof Tooltip>;
+
+export const Basic: Story = {
+  args: {
+    color: 'gray',
+    content: '툴팁입니다!',
+  },
+  argTypes: {
+    color: {
+      control: {
+        type: 'select',
+        options: Object.keys(tooltipColorMap),
+      },
+    },
+    content: {
+      control: {
+        type: 'text',
+      },
+    },
+  },
+  render: (args) => (
+    <Flex>
+      <Tooltip {...args}>
+        <Icon name="youtube" size={25} />
+      </Tooltip>
+    </Flex>
+  ),
+};

--- a/src/shared/ui/Tooltip/Tooltip.stories.tsx
+++ b/src/shared/ui/Tooltip/Tooltip.stories.tsx
@@ -27,6 +27,7 @@ export const Basic: Story = {
   args: {
     color: 'gray',
     content: '툴팁입니다!',
+    animationMode: 'SPRING',
   },
   argTypes: {
     color: {
@@ -40,6 +41,58 @@ export const Basic: Story = {
         type: 'text',
       },
     },
+    animationMode: {
+      control: {
+        type: 'select',
+        options: ['SPRING', 'POP', 'SMOOTH'],
+      },
+      description: '툴팁 애니메이션 모드를 선택하세요',
+    },
+  },
+  render: (args) => (
+    <Flex>
+      <Tooltip {...args}>
+        <Icon name="youtube" size={25} />
+      </Tooltip>
+    </Flex>
+  ),
+};
+
+export const SpringAnimation: Story = {
+  args: {
+    color: 'primary',
+    content: '스프링!',
+    animationMode: 'SPRING',
+  },
+  render: (args) => (
+    <Flex>
+      <Tooltip {...args}>
+        <Icon name="youtube" size={25} />
+      </Tooltip>
+    </Flex>
+  ),
+};
+
+export const PopAnimation: Story = {
+  args: {
+    color: 'green',
+    content: '뿅!',
+    animationMode: 'POP',
+  },
+  render: (args) => (
+    <Flex>
+      <Tooltip {...args}>
+        <Icon name="youtube" size={25} />
+      </Tooltip>
+    </Flex>
+  ),
+};
+
+export const SmoothAnimation: Story = {
+  args: {
+    color: 'purple',
+    content: '부드러운 애니메이션',
+    animationMode: 'SMOOTH',
   },
   render: (args) => (
     <Flex>

--- a/src/shared/ui/Tooltip/Tooltip.tsx
+++ b/src/shared/ui/Tooltip/Tooltip.tsx
@@ -1,3 +1,4 @@
+import { useId } from 'react';
 import { motion } from 'framer-motion';
 
 import { TOOLTIP_MOTION } from '@/shared/constants/motion';
@@ -35,15 +36,28 @@ export function Tooltip({
   animationMode = 'SPRING',
   children,
 }: TooltipProps) {
+  const tooltipId = useId();
   const { open, ref, show, hide, position } = useFloating();
   const selectedColor = tooltipColorMap[color];
   const animation = TOOLTIP_MOTION[animationMode];
 
   return (
-    <div ref={ref} className="inline-flex" onMouseEnter={show} onMouseLeave={hide}>
+    <div
+      ref={ref}
+      className="inline-flex"
+      onMouseEnter={show}
+      onMouseLeave={hide}
+      onFocus={show}
+      onBlur={hide}
+      onClick={() => (open ? hide() : show())}
+      aria-describedby={open ? tooltipId : undefined}
+    >
       {children}
       <Portal isOpen={open}>
         <motion.div
+          id={tooltipId}
+          role="tooltip"
+          aria-live="polite"
           initial={animation.initial}
           animate={animation.animate}
           exit={animation.exit}

--- a/src/shared/ui/Tooltip/Tooltip.tsx
+++ b/src/shared/ui/Tooltip/Tooltip.tsx
@@ -2,7 +2,7 @@ import { useId } from 'react';
 import { motion } from 'framer-motion';
 
 import { TOOLTIP_MOTION } from '@/shared/constants/motion';
-import { useFloating } from '@/shared/hooks/useFloating';
+import { useTooltip } from '@/shared/hooks/useTooltip';
 import { Colors } from '@/shared/lib/colors';
 import { cn } from '@/shared/lib/core';
 
@@ -37,7 +37,7 @@ export function Tooltip({
   children,
 }: TooltipProps) {
   const tooltipId = useId();
-  const { open, ref, show, hide, position } = useFloating();
+  const { open, ref, show, hide, position } = useTooltip();
   const selectedColor = tooltipColorMap[color];
   const animation = TOOLTIP_MOTION[animationMode];
 

--- a/src/shared/ui/Tooltip/Tooltip.tsx
+++ b/src/shared/ui/Tooltip/Tooltip.tsx
@@ -3,7 +3,6 @@ import { motion } from 'framer-motion';
 
 import { TOOLTIP_MOTION } from '@/shared/constants/motion';
 import { useTooltip } from '@/shared/hooks/useTooltip';
-import { Colors } from '@/shared/lib/colors';
 import { cn } from '@/shared/lib/core';
 
 import { tooltipColorMap } from './tooltipColorMap';
@@ -19,7 +18,7 @@ type TooltipProps = {
   /**
    * The color of the tooltip
    */
-  color: Colors;
+  color: keyof typeof tooltipColorMap;
   /**
    * The animation mode for the tooltip
    */
@@ -62,7 +61,7 @@ export function Tooltip({
           animate={animation.animate}
           exit={animation.exit}
           className={cn(
-            'fixed mb-2 -translate-x-1/2 -translate-y-full rounded px-2 py-1 whitespace-nowrap shadow-lg',
+            'fixed -translate-x-1/2 -translate-y-full rounded px-2 py-1 whitespace-nowrap shadow-lg',
             selectedColor.bg
           )}
           style={{

--- a/src/shared/ui/Tooltip/Tooltip.tsx
+++ b/src/shared/ui/Tooltip/Tooltip.tsx
@@ -1,0 +1,50 @@
+import { useFloating } from '@/shared/hooks/useFloating';
+import { Colors } from '@/shared/lib/colors';
+import { cn } from '@/shared/lib/core';
+
+import { tooltipColorMap } from './tooltipColorMap';
+
+import { Portal } from '../Portal';
+import { Caption1 } from '../Typography';
+
+type TooltipProps = {
+  /**
+   * The content to display in the tooltip
+   */
+  content: string;
+  /**
+   * The color of the tooltip
+   */
+  color: Colors;
+  /**
+   * The content to display in the tooltip
+   */
+  children: React.ReactNode;
+};
+
+export function Tooltip({ content, color = 'gray', children }: TooltipProps) {
+  const { open, ref, show, hide, position } = useFloating();
+  const selectedColor = tooltipColorMap[color];
+
+  return (
+    <div ref={ref} className="inline-flex" onMouseEnter={show} onMouseLeave={hide}>
+      {children}
+      <Portal isOpen={open}>
+        <div
+          className={cn(
+            'fixed mb-2 -translate-x-1/2 -translate-y-full rounded px-2 py-1 whitespace-nowrap shadow-lg',
+            selectedColor.bg
+          )}
+          style={{
+            top: position?.top,
+            left: position?.left,
+          }}
+        >
+          <Caption1 weight="medium" className={selectedColor.text}>
+            {content}
+          </Caption1>
+        </div>
+      </Portal>
+    </div>
+  );
+}

--- a/src/shared/ui/Tooltip/Tooltip.tsx
+++ b/src/shared/ui/Tooltip/Tooltip.tsx
@@ -1,3 +1,6 @@
+import { motion } from 'framer-motion';
+
+import { TOOLTIP_MOTION } from '@/shared/constants/motion';
 import { useFloating } from '@/shared/hooks/useFloating';
 import { Colors } from '@/shared/lib/colors';
 import { cn } from '@/shared/lib/core';
@@ -17,20 +20,33 @@ type TooltipProps = {
    */
   color: Colors;
   /**
+   * The animation mode for the tooltip
+   */
+  animationMode?: keyof typeof TOOLTIP_MOTION;
+  /**
    * The content to display in the tooltip
    */
   children: React.ReactNode;
 };
 
-export function Tooltip({ content, color = 'gray', children }: TooltipProps) {
+export function Tooltip({
+  content,
+  color = 'gray',
+  animationMode = 'SPRING',
+  children,
+}: TooltipProps) {
   const { open, ref, show, hide, position } = useFloating();
   const selectedColor = tooltipColorMap[color];
+  const animation = TOOLTIP_MOTION[animationMode];
 
   return (
     <div ref={ref} className="inline-flex" onMouseEnter={show} onMouseLeave={hide}>
       {children}
       <Portal isOpen={open}>
-        <div
+        <motion.div
+          initial={animation.initial}
+          animate={animation.animate}
+          exit={animation.exit}
           className={cn(
             'fixed mb-2 -translate-x-1/2 -translate-y-full rounded px-2 py-1 whitespace-nowrap shadow-lg',
             selectedColor.bg
@@ -43,7 +59,7 @@ export function Tooltip({ content, color = 'gray', children }: TooltipProps) {
           <Caption1 weight="medium" className={selectedColor.text}>
             {content}
           </Caption1>
-        </div>
+        </motion.div>
       </Portal>
     </div>
   );

--- a/src/shared/ui/Tooltip/index.ts
+++ b/src/shared/ui/Tooltip/index.ts
@@ -1,0 +1,1 @@
+export { Tooltip } from './Tooltip';

--- a/src/shared/ui/Tooltip/tooltipColorMap.ts
+++ b/src/shared/ui/Tooltip/tooltipColorMap.ts
@@ -1,0 +1,38 @@
+export const tooltipColorMap = {
+  primary: {
+    bg: 'bg-primary-300',
+    text: 'text-white',
+  },
+  gray: {
+    bg: 'bg-gray-400',
+    text: 'text-white',
+  },
+  red: {
+    bg: 'bg-red-300',
+    text: 'text-white',
+  },
+  green: {
+    bg: 'bg-green-300',
+    text: 'text-white',
+  },
+  orange: {
+    bg: 'bg-orange-500',
+    text: 'text-white',
+  },
+  yellow: {
+    bg: 'bg-yellow-400',
+    text: 'text-black',
+  },
+  purple: {
+    bg: 'bg-purple-500',
+    text: 'text-white',
+  },
+  white: {
+    bg: 'bg-white border border-gray-200',
+    text: 'text-gray-800',
+  },
+  black: {
+    bg: 'bg-black',
+    text: 'text-white',
+  },
+} as const;


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FEAT] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BUGFIX] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [REFACTOR] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [CHORE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [TEST] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [PERFORMANCE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [SET] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [DOCS] 작업_내용을_한_줄로_요약해서_작성 -->

## 🔥 연관 이슈

- close #52

## 🚀 작업 내용

- Tooltip 컴포넌트, 스토리북 구현했습니다.
- z-index의 영향을 받지 않았으면 좋겠어서, Portal로 구현했어요. Portal을 사용했을 때 제가 생각한 장점은 다음과 같습니다!
  - z-index/겹침 문제 해결한다고 생각했어요. 부모 컴포넌트의 CSS overflow, position, z-index에 영향을 받지 않고 툴팁을 최상위에 띄울 수 있어 다른 UI 요소에 가려지지 않습니다.
  - dom 구조가 단순화 된다고 생각했어요. 툴팁이나 팝업을 부모 내부가 아닌 최상위에 두므로 부모 요소가 복잡해도 렌더링 위치나 이벤트 처리에 영향을 덜 받습니다.
- 사용하는 측에서 편리했으면 하는 마음에, [radix-ui](https://www.radix-ui.com/themes/docs/components/tooltip)를 참고해서 개발했어요. 사용방법은 아래와 같습니다! 

```tsx
<Tooltip content="툴팁입니다!">
  <Icon name="youtube" size={25} />
</Tooltip>
```
![Aug-26-2025 19-33-42](https://github.com/user-attachments/assets/18e87cb0-214f-4c46-b5bc-f3f6c23ae704)


## 🤔 고민했던 내용
- 조금 더 범용적인 툴팁을 고려해, position 값에 따라 위치 조정하는 기능도 고려했으나, 현재는 일정상 시간이 많지 않다고 판단해서 구현하지 못했어요. 🥹 나중에 필요에 따라 구현하도록 하겠습니다!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Tooltip 컴포넌트 추가: 호버/포커스/클릭으로 표시, 포털 렌더링, 접근성 속성 지원.
  * 색상 테마 제공(여러 컬러 옵션) 및 3가지 애니메이션 모드(SPRING, POP, SMOOTH).
* Documentation
  * Storybook에 기본/SPRING/POP/SMOOTH 데모 스토리 추가.
  * 컨트롤을 통해 색상, 내용, 애니메이션 모드 실시간 변경 가능.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->