### PR TITLE
[BUGFIX] Select 레이아웃 쉬프트 문제 

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,7 +1,7 @@
 language: 'ko-KR'
 early_access: false
 reviews:
-  profile: 'chill'
+  profile: 'assertive'
   request_changes_workflow: false
   high_level_summary: true
   poem: false
@@ -9,6 +9,7 @@ reviews:
   collapse_walkthrough: false
   auto_review:
     enabled: true
-    drafts: false
+    drafts: true
+    base_branches: ['.*']
 chat:
   auto_reply: true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ddingdong-design-system",
-  "version": "0.2.7",
+  "version": "0.2.9",
   "type": "module",
   "keywords": [
     "react",

--- a/src/shared/ui/Badge/Badge.tsx
+++ b/src/shared/ui/Badge/Badge.tsx
@@ -14,7 +14,7 @@ type Props = {
 } & React.HTMLAttributes<HTMLDivElement>;
 
 const variantStyles = {
-  positive: 'bg-green-100 text-green-300',
+  positive: 'bg-green-50 text-green-200',
   negative: 'bg-red-100 text-red-300',
   neutral: 'bg-gray-100 text-gray-400',
 };

--- a/src/shared/ui/Select/Option.tsx
+++ b/src/shared/ui/Select/Option.tsx
@@ -20,20 +20,23 @@ const optionVariants = cva(
 );
 
 type Props = {
-  id: string;
+  /**
+   * The display name for the option.
+   */
   name: string;
+  /**
+   * Additional classes to apply to the option.
+   */
+  className?: string;
 } & VariantProps<typeof optionVariants>;
 
-export function Option({ id, name, size }: Props) {
-  const { onSelect, size: contextSize } = useSelectContext() as {
-    onSelect: (arg: { id: string; name: string }) => void;
-    size: 'md' | 'lg';
-  };
+export function Option({ name, size, className }: Props) {
+  const { onSelect, size: contextSize } = useSelectContext();
 
   return (
     <div
-      onClick={() => onSelect({ id, name })}
-      className={cn(optionVariants({ size: size || contextSize }))}
+      onClick={() => onSelect(name)}
+      className={cn(optionVariants({ size: size || contextSize }), className)}
     >
       {name}
     </div>

--- a/src/shared/ui/Select/Option.tsx
+++ b/src/shared/ui/Select/Option.tsx
@@ -31,11 +31,20 @@ type Props = {
 } & VariantProps<typeof optionVariants>;
 
 export function Option({ name, size, className }: Props) {
-  const { onSelect, size: contextSize } = useSelectContext();
+  const { onSelect, size: contextSize, selected } = useSelectContext();
 
   return (
     <div
+      role="option"
+      tabIndex={0}
+      aria-selected={selected === name}
       onClick={() => onSelect(name)}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          onSelect(name);
+        }
+      }}
       className={cn(optionVariants({ size: size || contextSize }), className)}
     >
       {name}

--- a/src/shared/ui/Select/OptionList.tsx
+++ b/src/shared/ui/Select/OptionList.tsx
@@ -5,7 +5,7 @@ import { cn } from '@/shared/lib/core';
 import { useSelectContext } from './Select.context';
 
 const optionListVariants = cva(
-  'mt-1 max-h-60 overflow-y-auto rounded-md border border-gray-200 bg-white font-semibold text-gray-400',
+  'absolute top-full left-0 z-50 mt-1 max-h-60 w-full overflow-y-auto rounded-md border border-gray-200 bg-white font-semibold text-gray-400 shadow-lg',
   {
     variants: {
       size: {

--- a/src/shared/ui/Select/Select.context.tsx
+++ b/src/shared/ui/Select/Select.context.tsx
@@ -1,20 +1,26 @@
 import { createContext, useContext } from 'react';
 
-type OptionProps = {
-  id: string;
-  name: string;
-};
-
 export type SelectContextType = {
-  selected: OptionProps;
-  onSelect: (option: OptionProps) => void;
+  /**
+   * The currently selected option.
+   */
+  selected: string;
+  /**
+   * Callback function called when the selected option changes.
+   * @returns
+   */
+  onSelect: (option: string) => void;
+  /**
+   * The size of the select component.
+   */
   size: 'md' | 'lg';
 };
 
-export const SelectContext = createContext<SelectContextType | undefined>(undefined);
+export const SelectContext = createContext<SelectContextType | null>(null);
 
 export const useSelectContext = () => {
   const context = useContext(SelectContext);
   if (!context) throw new Error('error');
+
   return context;
 };

--- a/src/shared/ui/Select/Select.stories.tsx
+++ b/src/shared/ui/Select/Select.stories.tsx
@@ -1,4 +1,4 @@
-import { Fragment } from 'react';
+import { Fragment, useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 
 import { GroupingSelect, Select } from './index';
@@ -21,7 +21,6 @@ const meta = {
 } satisfies Meta<typeof Select>;
 
 export default meta;
-
 type Story = StoryObj<typeof Select>;
 
 const defaultContents = ['객관식', '단답형', '체크박스', '드롭다운', '파일'];
@@ -35,20 +34,27 @@ export const Basic: Story = {
     },
   },
   args: {
+    value: '유형을 선택해주세요',
     size: 'md',
     defaultValue: '유형을 선택해주세요',
   },
-  render: (args) => (
-    <Select {...args}>
-      {defaultContents.map((item, index) => (
-        <Select.Option key={index} id={String(index + 1)} name={item} />
-      ))}
-    </Select>
-  ),
+  render: (args) => {
+    const [value, setValue] = useState(args.defaultValue);
+    return (
+      <div className="h-50">
+        <Select {...args} value={value} onChange={setValue}>
+          {defaultContents.map((item, index) => (
+            <Select.Option key={index} name={item} />
+          ))}
+        </Select>
+      </div>
+    );
+  },
 };
 
 export const LargeSize: Story = {
   args: {
+    value: '유형을 선택해주세요',
     size: 'lg',
     defaultValue: '유형을 선택해주세요',
   },
@@ -59,13 +65,18 @@ export const LargeSize: Story = {
       },
     },
   },
-  render: (args) => (
-    <Select {...args}>
-      {defaultContents.map((item, index) => (
-        <Select.Option key={index} id={index.toString()} name={item} />
-      ))}
-    </Select>
-  ),
+  render: (args) => {
+    const [value, setValue] = useState(args.defaultValue);
+    return (
+      <div className="h-62">
+        <Select {...args} value={value} onChange={setValue}>
+          {defaultContents.map((item, index) => (
+            <Select.Option key={index} name={item} />
+          ))}
+        </Select>
+      </div>
+    );
+  },
 };
 
 const groupingContents = {
@@ -114,16 +125,22 @@ export const Grouping: StoryObj<typeof GroupingSelect> = {
       },
     },
   },
-  render: (args) => (
-    <GroupingSelect {...args}>
-      {Object.entries(groupingContents).map(([group, departments]) => (
-        <Fragment key={group}>
-          <GroupingSelect.Group name={group} />
-          {departments.map((dept, idx) => (
-            <GroupingSelect.Option key={`${group}-${idx}`} id={`${group}-${idx}`} name={dept} />
+  render: (args) => {
+    const [value, setValue] = useState(args.defaultValue);
+
+    return (
+      <div className="h-62">
+        <GroupingSelect {...args} value={value} onChange={setValue}>
+          {Object.entries(groupingContents).map(([group, departments]) => (
+            <Fragment key={group}>
+              <GroupingSelect.Group name={group} />
+              {departments.map((dept, idx) => (
+                <GroupingSelect.Option key={`${group}-${idx}`} name={dept} />
+              ))}
+            </Fragment>
           ))}
-        </Fragment>
-      ))}
-    </GroupingSelect>
-  ),
+        </GroupingSelect>
+      </div>
+    );
+  },
 };

--- a/src/shared/ui/Select/SelectButton.tsx
+++ b/src/shared/ui/Select/SelectButton.tsx
@@ -3,18 +3,31 @@ import { cn } from '@/shared/lib/core';
 import { Icon } from '../Icon';
 
 type Props = {
+  /**
+   * The currently selected option.
+   */
   selected: string;
+  /**
+   * Callback function to be called when the button is clicked.
+   * @returns void
+   */
   onClick: () => void;
+  /**
+   * Whether the dropdown is open or closed.
+   */
   isOpen: boolean;
+  /**
+   * The size of the button.
+   */
   size?: 'md' | 'lg';
 };
 
-export function SelectButton({ selected, onClick, isOpen, size = 'lg' }: Props) {
-  const sizeVariants = {
-    md: 'px-3 py-1 text-sm w-fit min-w-24',
-    lg: 'px-5 py-1.5 md:py-2.5 min-w-64 md:w-72 text-base md:text-lg',
-  };
+const sizeVariants = {
+  md: 'px-3 py-1 text-sm w-fit min-w-24',
+  lg: 'px-5 py-1.5 md:py-2.5 min-w-64 md:w-72 text-base md:text-lg',
+} as const;
 
+export function SelectButton({ selected, onClick, isOpen, size = 'lg' }: Props) {
   return (
     <div
       onClick={onClick}

--- a/src/shared/ui/Select/SelectMain.tsx
+++ b/src/shared/ui/Select/SelectMain.tsx
@@ -1,13 +1,8 @@
-import { ReactNode, useState } from 'react';
+import { ComponentProps, ReactNode, useState } from 'react';
 
 import { OptionList } from './OptionList';
 import { SelectContext } from './Select.context';
 import { SelectButton } from './SelectButton';
-
-type OptionProps = {
-  id: string;
-  name: string;
-};
 
 type Props = {
   /**
@@ -16,9 +11,13 @@ type Props = {
    */
   size?: 'md' | 'lg';
   /**
+   * The currently selected option.
+   */
+  value: string;
+  /**
    * Callback function called when the selected option changes.
    */
-  onChange?: (option: OptionProps) => void;
+  onChange?: (option: string) => void;
   /**
    * The default value of the select component.
    */
@@ -27,26 +26,27 @@ type Props = {
    * The content to be displayed inside the select component.
    */
   children: ReactNode;
-};
+} & Omit<ComponentProps<'select'>, 'value' | 'onChange' | 'size'>;
 
-export function SelectMain({ children, defaultValue, onChange, size = 'lg' }: Props) {
-  const [selected, setSelected] = useState<OptionProps>({
-    id: '',
-    name: defaultValue,
-  });
+export function SelectMain({ value, onChange, size = 'lg', children }: Props) {
   const [isOpen, setIsOpen] = useState(false);
 
-  const handleSelect = (option: OptionProps) => {
-    setSelected(option);
+  const handleSelect = (option: string) => {
     setIsOpen(false);
     onChange?.(option);
   };
 
   return (
-    <SelectContext.Provider value={{ selected, onSelect: handleSelect, size }}>
+    <SelectContext.Provider
+      value={{
+        selected: value,
+        onSelect: handleSelect,
+        size: size,
+      }}
+    >
       <div className="relative w-fit">
         <SelectButton
-          selected={selected.name}
+          selected={value}
           onClick={() => setIsOpen(!isOpen)}
           size={size}
           isOpen={isOpen}

--- a/src/shared/ui/assets/index.tsx
+++ b/src/shared/ui/assets/index.tsx
@@ -14,6 +14,7 @@ import Loading from './loading.svg';
 import NavbarArrow from './navbar-arrow.svg';
 import New from './new.svg';
 import Pin from './pin.svg';
+import Search from './search.svg';
 import Trash from './trash.svg';
 import Write from './write.svg';
 import Youtube from './youtube.svg';
@@ -33,6 +34,7 @@ export const Icons = {
   navbarArrow: NavbarArrow,
   new: New,
   pin: Pin,
+  search: Search,
   trash: Trash,
   write: Write,
   loading: Loading,

--- a/src/shared/ui/assets/search.svg
+++ b/src/shared/ui/assets/search.svg
@@ -1,0 +1,4 @@
+<svg width="current" height="current" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M10.5 15C13.2614 15 15.5 12.7614 15.5 10C15.5 7.23858 13.2614 5 10.5 5C7.73858 5 5.5 7.23858 5.5 10C5.5 12.7614 7.73858 15 10.5 15Z" stroke="currentColor" stroke-width="1.5"/>
+<path d="M13.5 14L18.5 19" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+</svg>


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FEAT] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BUGFIX] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [REFACTOR] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [CHORE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [TEST] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [PERFORMANCE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [SET] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [DOCS] 작업_내용을_한_줄로_요약해서_작성 -->

## 🔥 연관 이슈

- close #60

## 🚀 작업 내용

- 이슈에 적혀있듯이, optionList 가 레이아웃을 밀어내는 현상이 있어 개선했습니다. 
- absolute 포지셔닝을 적용하여 레이아웃 영향을 방지했습니다. 
- 불필요한 내부 상태였던 selected를 제거하여 코드를 정리했습니다.

**원인**
- 옵션 리스트가 absolute로 떠야 하지만, 현재 static 위치에서 렌더링되고 있음
- 부모 컨테이너의 스타일(overflow, position 등) 영향으로 의도한 위치에 표시되지 않음 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 공유 아이콘 세트에 Search 아이콘을 추가했습니다.
- Refactor
  - Select를 제어형으로 전환했습니다(value 필수, onChange는 string).
  - Select.Option의 id 제거, onSelect(name) 호출로 단순화하고 className으로 외부 스타일 확장 지원.
  - Select 관련 컨텍스트와 버튼/컴포넌트 동작을 문자열 기반으로 통일 및 소소한 내부 최적화 수행.
- Style
  - 긍정 배지 색상을 더 연한 톤으로 조정했습니다.
  - 옵션 리스트에 절대 배치·전체 너비·높은 z-index·그림자를 적용해 가시성 개선.
- Documentation
  - 스토리북을 제어형 사용 예로 갱신했습니다.
- Chores
  - 패키지 버전을 0.2.9로 업데이트했고 설정 파일의 리뷰/자동검토 관련 옵션을 조정했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->