### PR TITLE
[FIX] Accordion trigger내 Input 사용 동작 제어

### DIFF
--- a/src/shared/ui/Accordion/Accordion.stories.tsx
+++ b/src/shared/ui/Accordion/Accordion.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
 import { AccordionItem, Accordion } from '.';
+import { Input } from '../Input';
 
 const meta: Meta<typeof Accordion> = {
   title: 'components/Accordion',
@@ -57,6 +58,17 @@ export const NoneArrowAccordion: Story = {
         </AccordionItem>
         <AccordionItem value="item-2" isArrow={false} trigger={<div>질문 2</div>}>
           <div>내용</div>
+        </AccordionItem>
+      </Accordion>
+    );
+  },
+};
+export const InputAccordion: Story = {
+  render: () => {
+    return (
+      <Accordion type="single">
+        <AccordionItem value="item-1" trigger={<Input onClickReset={() => {}} />}>
+          <Input onClickReset={() => {}} />
         </AccordionItem>
       </Accordion>
     );

--- a/src/shared/ui/Accordion/Accordion.tsx
+++ b/src/shared/ui/Accordion/Accordion.tsx
@@ -108,11 +108,11 @@ export function AccordionItem({
 
   return (
     <div className="border-b border-gray-200" data-state={isOpen ? 'open' : 'closed'} {...props}>
-      <button
+      <div
         id={triggerId}
         aria-controls={contentId}
         aria-expanded={isOpen}
-        type="button"
+        role="button"
         onClick={() => toggleItem(value)}
         className={cn(
           'flex w-full cursor-pointer items-center justify-between px-6 py-4 text-left hover:bg-gray-50',
@@ -129,7 +129,7 @@ export function AccordionItem({
             <Icon name="arrowDown" size={20} />
           </motion.div>
         )}
-      </button>
+      </div>
 
       <AnimatePresence initial={false}>
         {isOpen && (

--- a/src/shared/ui/Accordion/Accordion.tsx
+++ b/src/shared/ui/Accordion/Accordion.tsx
@@ -7,6 +7,11 @@ import { AccordionContext, useAccordion } from './Accordion.context';
 
 import { Icon } from '../Icon';
 
+function isInteractiveElement(element: HTMLElement) {
+  const INTERACTIVE_TAGS = ['INPUT', 'TEXTAREA', 'A'];
+  return INTERACTIVE_TAGS.includes(element.tagName);
+}
+
 type AccordionRootProps = {
   /**
    * The type of the Accordion, either single or multiple.
@@ -106,14 +111,22 @@ export function AccordionItem({
   const { openItems, toggleItem } = context;
   const isOpen = openItems.includes(value);
 
+  const handleClickTrigger = (e: React.MouseEvent<HTMLButtonElement>) => {
+    const target = e.target as HTMLElement;
+    if (isInteractiveElement(target)) {
+      return e.stopPropagation();
+    }
+    toggleItem(value);
+  };
+
   return (
     <div className="border-b border-gray-200" data-state={isOpen ? 'open' : 'closed'} {...props}>
-      <div
+      <button
         id={triggerId}
         aria-controls={contentId}
         aria-expanded={isOpen}
-        role="button"
-        onClick={() => toggleItem(value)}
+        type="button"
+        onClick={handleClickTrigger}
         className={cn(
           'flex w-full cursor-pointer items-center justify-between px-6 py-4 text-left hover:bg-gray-50',
           btnClassName
@@ -129,7 +142,7 @@ export function AccordionItem({
             <Icon name="arrowDown" size={20} />
           </motion.div>
         )}
-      </div>
+      </button>
 
       <AnimatePresence initial={false}>
         {isOpen && (

--- a/src/shared/ui/Accordion/Accordion.tsx
+++ b/src/shared/ui/Accordion/Accordion.tsx
@@ -7,11 +7,6 @@ import { AccordionContext, useAccordion } from './Accordion.context';
 
 import { Icon } from '../Icon';
 
-function isInteractiveElement(element: HTMLElement) {
-  const INTERACTIVE_TAGS = ['INPUT', 'TEXTAREA', 'A'];
-  return INTERACTIVE_TAGS.includes(element.tagName);
-}
-
 type AccordionRootProps = {
   /**
    * The type of the Accordion, either single or multiple.
@@ -93,6 +88,11 @@ const ACCORDION_MOTION = {
   },
 };
 
+const isInteractiveElement = (element: HTMLElement) => {
+  const INTERACTIVE_TAGS = ['INPUT', 'TEXTAREA', 'A'];
+  return INTERACTIVE_TAGS.includes(element.tagName);
+};
+
 export function AccordionItem({
   trigger,
   isArrow = true,
@@ -111,21 +111,22 @@ export function AccordionItem({
   const { openItems, toggleItem } = context;
   const isOpen = openItems.includes(value);
 
-  const handleClickTrigger = (e: React.MouseEvent<HTMLButtonElement>) => {
+  const handleClickTrigger = (e: React.MouseEvent<HTMLDivElement>) => {
     const target = e.target as HTMLElement;
     if (isInteractiveElement(target)) {
       return e.stopPropagation();
     }
+
     toggleItem(value);
   };
 
   return (
     <div className="border-b border-gray-200" data-state={isOpen ? 'open' : 'closed'} {...props}>
-      <button
+      <div
         id={triggerId}
         aria-controls={contentId}
         aria-expanded={isOpen}
-        type="button"
+        role="button"
         onClick={handleClickTrigger}
         className={cn(
           'flex w-full cursor-pointer items-center justify-between px-6 py-4 text-left hover:bg-gray-50',
@@ -142,7 +143,7 @@ export function AccordionItem({
             <Icon name="arrowDown" size={20} />
           </motion.div>
         )}
-      </button>
+      </div>
 
       <AnimatePresence initial={false}>
         {isOpen && (


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FEAT] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BUGFIX] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [REFACTOR] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [CHORE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [TEST] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [PERFORMANCE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [SET] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [DOCS] 작업_내용을_한_줄로_요약해서_작성 -->

## 🔥 연관 이슈

- close #73 

## 🚀 작업 내용




- AccordionItem 컴포넌트는 trigger에 button tag가 설정되어 있어요. input에서 space가 발생하는 경우, 부모의 클릭 핸들러까지 이벤트 버블링이 전달되어 button이 클릭 처리되는 것이 원인이에요. `button` -> `div` 변경을 통해 해소했어요.
- 상호작용이 발생할 수 있는 컴포넌트 중 trigger에 사용될수 있는 input, textarea, a 태그를 대상으로 클릭 시 버블링 문제를 해소했고, 스토리북을 통해서 확인가능해요.

## 🤔 고민했던 내용
- `input`, `textarea`, `a` 이외의 다른 컴포넌트가 추가가 필요하다면 말씀해주세요!
- `isInteractiveElement` 함수의 경우 util로 빼려다가, 해당 컴포넌트를 제외하고 사용될 가능성이 낮다고 판단해 `Accordion`에 위치시켰습니다!

https://github.com/user-attachments/assets/35f64116-865c-4e16-9415-08ea8b978950

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 버그 수정
  - 아코디언 트리거 내부의 입력 필드, 텍스트 영역, 링크 등을 클릭해도 패널이 의도치 않게 열리거나 닫히지 않도록 동작을 개선했습니다. 일반 영역 클릭 시에는 기존처럼 토글됩니다. 사용성과 접근성이 향상됩니다.
- 문서화
  - 입력 필드를 트리거와 콘텐츠로 사용하는 단일 아코디언 예시를 스토리북에 추가했습니다. 상호작용 요소를 포함한 상황에서의 동작을 손쉽게 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->