### PR TITLE
[CHORE] main 브랜치 머지 시 npm 자동 배포 및 버저닝 설정

### DIFF
--- a/.github/workflows/auto-bump-version.yaml
+++ b/.github/workflows/auto-bump-version.yaml
@@ -42,26 +42,61 @@ jobs:
             const touched = files.some(f => f.filename === 'package.json' && /"version"\s*:/.test(f.patch || ''));
             core.setOutput('changed', touched ? 'true' : 'false');
 
-      - name: Bump patch version (+0.0.1) if not changed in PR
+      - name: Detect if new UI folder added
+        id: new_ui_folder
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request.number;
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr,
+              per_page: 100
+            });
+
+            const addedDirs = new Set();
+            for (const f of files) {
+              if (f.status === 'added' && f.filename.startsWith('src/shared/ui/')) {
+                const parts = f.filename.split('/');
+                if (parts.length > 3) {
+                  addedDirs.add(parts.slice(0, 4).join('/')); // 예: src/shared/ui/Button
+                }
+              }
+            }
+
+            core.setOutput('new_ui_folder', addedDirs.size > 0 ? 'true' : 'false');
+            console.log('New UI folders detected:', Array.from(addedDirs));
+
+      - name: Bump version based on PR type
         if: steps.ver_changed.outputs.changed != 'true'
         run: |
           node -e "
             const fs = require('fs');
-            const pr_title = context.payload.pull_request.title;
+            const pr_title = process.env.PR_TITLE;
+            const is_new_ui = process.env.NEW_UI_FOLDER === 'true';
             const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
             const [a, b, c] = pkg.version.split('.').map(Number);
             let new_version;
 
-            if (pr_title.toLowerCase().startsWith('feat')) {
+            if (is_new_ui) {
+              new_version = [a + 1, 0, 0].join('.');
+              console.log('Major bump (new UI folder added)');
+            } else if (pr_title.toLowerCase().startsWith('feat')) {
               new_version = [a, b + 1, 0].join('.');
+              console.log('Minor bump (feat detected)');
             } else {
               new_version = [a, b, c + 1].join('.');
+              console.log('Patch bump (default)');
             }
 
             pkg.version = new_version;
             fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
             console.log('Bumped to', pkg.version);
           "
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          NEW_UI_FOLDER: ${{ steps.new_ui_folder.outputs.new_ui_folder }}
 
       - name: Install dependencies
         run: npm ci
@@ -87,7 +122,6 @@ jobs:
                 .forEach(dir => {
                   const dirPath = path.join(uiRoot, dir.name);
                   const innerItems = fs.readdirSync(dirPath, { withFileTypes: true });
-
                   for (const item of innerItems) {
                     if (item.isFile() && (item.name.endsWith('.ts') || item.name.endsWith('.tsx')) && item.name !== 'index.ts') {
                       componentFiles.push(path.join(dir.name, item.name));
@@ -99,10 +133,7 @@ jobs:
             for (const relativeFilePath of componentFiles) {
               const componentName = path.basename(relativeFilePath, path.extname(relativeFilePath));
               const exportPath = './ui/' + relativeFilePath.replace(path.extname(relativeFilePath), '');
-
-              if (existingExports.has(exportPath)) {
-                continue;
-              }
+              if (existingExports.has(exportPath)) continue;
               const line = \`export { \${componentName} } from '\${exportPath}'\`;
               adds.push(line);
             }


### PR DESCRIPTION
<!-- [CHORE] main 브랜치 머지 시 npm 자동 배포 및 버저닝 설정 -->

## 🔥 연관 이슈

- close #84 

## 🚀 작업 내용
1. 버전 자동 증가 (ui 하위 새 폴더 추가됐을 경우 Major 버전,feat 커밋일 경우 Minor 버전, 그 외는 Patch 버전).

2. `src/shared/ui/ComponentName/ComponentName.tsx`와 같은 패턴을 가진 새로운 컴포넌트의 내보내기 구문을 `src/shared/index.ts`에 자동으로 추가합니다.
( 다만 Typography처럼 하나의 파일에서 여러 개의 식별자를 내보내는 경우는 처리가 불가합니다 ) 

4. 빌드 및 커밋/푸시를 수행합니다.

5. 새 버전을 npm에 게시합니다.

## 💬 리뷰 중점사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * main으로 병합된 PR에서 자동으로 버전을 증가시키는 워크플로우 추가(기본 패치, PR 제목이 "feat"이면 마이너, 새 UI 추가 시 메이저 기준).
  * 새 UI 컴포넌트가 감지되면 공개 익스포트 목록을 자동으로 동기화.
  * 변경 사항이 감지되면 자동으로 빌드·커밋·퍼블리시를 수행하고, 변경 없으면 퍼블리시를 건너뜀.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->