### PR TITLE
[FEAT] Header 컴포넌트 제작

### DIFF
--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -24,6 +24,7 @@ export { Tabs, TabItem } from './ui/Tabs';
 export { TextArea } from './ui/TextArea';
 export { Tooltip } from './ui/Tooltip';
 export { Title1, Title2, Title3, Caption1, Body1, Body2, Body3 } from './ui/Typography';
+export { Header, NavigationItem, MenuContainer, Menu, MenuTrigger, MenuItem } from './ui/Header';
 
 export { Icons, iconNames } from './ui/assets';
 export type { IconName } from './ui/assets';

--- a/src/shared/ui/Header/Header.stories.tsx
+++ b/src/shared/ui/Header/Header.stories.tsx
@@ -1,0 +1,111 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { Header } from './Header';
+import { Menu } from './Menu';
+import { MenuContainer } from './MenuContext';
+import { MenuItem } from './MenuItem';
+import { MenuTrigger } from './MenuTrigger';
+import { NavigationItem } from './NavigationItem';
+
+import { Flex } from '../Flex';
+
+const navItems = {
+  총동아리연합회: [
+    { id: 1, href: '/notice', content: '공지사항' },
+    { id: 2, href: '/documents', content: '자료실' },
+    { id: 3, href: '/faq', content: 'FAQ' },
+  ],
+  동아리피드: [{ id: 4, href: '/feeds', content: '피드' }],
+  SNS: [
+    { id: 5, href: 'https://pf.kakao.com/_ExmtkG', content: '카카오톡' },
+    { id: 6, href: 'https://www.instagram.com/mju_club_', content: '인스타그램' },
+  ],
+};
+
+const meta = {
+  title: 'Components/Header',
+  component: Header,
+  tags: ['autodocs'],
+  decorators: [
+    (Story) => (
+      <div style={{ minHeight: '170px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Header 컴포넌트는 로고 및 탐색(Navigation) 메뉴와 같은 주요 요소를 담는 상단 컨테이너입니다.',
+      },
+    },
+  },
+} satisfies Meta<typeof Header>;
+
+export default meta;
+type Story = StoryObj<typeof Header>;
+
+export const Basic: Story = {
+  args: {
+    children: (
+      <a href="https://ddingdong.mju.ac.kr/">
+        <img
+          src="https://ddingdong.mju.ac.kr/_next/image?url=%2Flogo.png&w=3840&q=75"
+          width="120"
+          alt="LOGO"
+        />
+      </a>
+    ),
+  },
+};
+
+export const WithNavigation: Story = {
+  args: {
+    children: (
+      <Flex dir="row" alignItems="center" className="w-full">
+        <a href="https://ddingdong.mju.ac.kr/">
+          <img
+            src="https://ddingdong.mju.ac.kr/_next/image?url=%2Flogo.png&w=3840&q=75"
+            width="150"
+            alt="LOGO"
+          />
+        </a>
+        <Flex dir="row" alignItems="center" justifyContent="between" className="h-full w-full pl-6">
+          <Flex dir="row" alignItems="center" className="ml-auto gap-4">
+            {Object.entries(navItems).map(([category, items]) => {
+              if (items.length === 1) {
+                const item = items[0];
+                return (
+                  <NavigationItem key={category} href={item.href}>
+                    {category}
+                  </NavigationItem>
+                );
+              }
+              return (
+                <MenuContainer key={category}>
+                  <MenuTrigger>{category}</MenuTrigger>
+                  <Menu>
+                    {items.map((item) => {
+                      const isExternal = /^https?:\/\//.test(item.href);
+                      return (
+                        <MenuItem
+                          key={item.id}
+                          href={item.href}
+                          target={isExternal ? '_blank' : '_self'}
+                          rel="noopener noreferrer"
+                        >
+                          {item.content}
+                        </MenuItem>
+                      );
+                    })}
+                  </Menu>
+                </MenuContainer>
+              );
+            })}
+          </Flex>
+        </Flex>
+      </Flex>
+    ),
+  },
+};

--- a/src/shared/ui/Header/Header.tsx
+++ b/src/shared/ui/Header/Header.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { cn } from '@/shared/lib/core';
+
+import { Flex } from '../Flex';
+
+export type Props = {
+  children: React.ReactNode;
+  className?: string;
+};
+
+export function Header({ children, className }: Props) {
+  return (
+    <header
+      className={cn(
+        'fixed top-0 left-0 z-10 w-full border-b border-gray-200 bg-white px-6 md:z-20',
+        className
+      )}
+    >
+      <Flex
+        as="div"
+        dir="row"
+        alignItems="center"
+        justifyContent="between"
+        className="mx-auto h-16 w-full max-w-6xl md:h-[72px] md:px-16"
+      >
+        {children}
+      </Flex>
+    </header>
+  );
+}

--- a/src/shared/ui/Header/Menu.tsx
+++ b/src/shared/ui/Header/Menu.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import { useRef } from 'react';
+
+import { useClickOutside } from './useClickOutside';
+import { useMenuCtx } from './useMenuCtx';
+
+import { cn } from '../../lib/core';
+
+type Props = {
+  children: React.ReactNode;
+  className?: string;
+};
+
+export function Menu({ children, className }: Props) {
+  const { open, contentId, triggerId, setOpen } = useMenuCtx();
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  useClickOutside({
+    ref: menuRef,
+    handler: () => setOpen(false),
+  });
+
+  if (!open) return null;
+
+  return (
+    <div
+      ref={menuRef}
+      id={contentId}
+      role="menu"
+      aria-labelledby={triggerId}
+      className={cn(
+        'ring-opacity-5 absolute left-1/2 mt-6 w-fit min-w-25 -translate-x-1/2 transform justify-center overflow-hidden rounded-lg border border-gray-200 bg-white text-center whitespace-nowrap text-neutral-500 shadow-xl',
+        className
+      )}
+    >
+      {children}
+    </div>
+  );
+}

--- a/src/shared/ui/Header/MenuContext.tsx
+++ b/src/shared/ui/Header/MenuContext.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import { useId, useState, type Ref } from 'react';
+
+import { MenuContext } from './menu-context';
+
+import { cn } from '../../lib/core';
+
+type Props = {
+  children: React.ReactNode;
+  className?: string;
+  defaultOpen?: boolean;
+  containerRef?: Ref<HTMLDivElement>;
+};
+
+export function MenuContainer({ children, className, defaultOpen = false, containerRef }: Props) {
+  const [open, setOpen] = useState(defaultOpen);
+  const triggerId = useId();
+  const contentId = useId();
+
+  return (
+    <MenuContext.Provider value={{ open, setOpen, triggerId, contentId }}>
+      <div ref={containerRef} className={cn('relative', className)}>
+        {children}
+      </div>
+    </MenuContext.Provider>
+  );
+}

--- a/src/shared/ui/Header/MenuItem.tsx
+++ b/src/shared/ui/Header/MenuItem.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import { ReactNode } from 'react';
+
+import { cn } from '@/shared/lib/core';
+
+import { useMenuCtx } from './useMenuCtx';
+
+import { IconName } from '../assets';
+import { Icon } from '../Icon';
+import { Body3 } from '../Typography';
+
+export type Props = {
+  children: ReactNode;
+  onClick?: () => void;
+  href?: string;
+  rel?: string;
+  target?: React.AnchorHTMLAttributes<HTMLAnchorElement>['target'];
+  icon?: IconName;
+  className?: string;
+  disabled?: boolean;
+};
+
+export function MenuItem({
+  children,
+  onClick,
+  href,
+  rel,
+  target = '_self',
+  icon,
+  className,
+}: Props) {
+  const { setOpen } = useMenuCtx();
+
+  const common = cn(
+    'flex w-full items-center font-semibold gap-3 whitespace-nowrap px-4 py-2 text-gray-400 transition-colors duration-150 hover:bg-gray-100',
+    className
+  );
+
+  if (href) {
+    return (
+      <a
+        href={href}
+        target={target}
+        rel={rel}
+        className={common}
+        role="menuitem"
+        onClick={() => setOpen(false)}
+      >
+        {icon && <Icon name={icon} size={16} />}
+        {children}
+      </a>
+    );
+  }
+
+  const handleMenuItemClick = () => {
+    onClick?.();
+    setOpen(false);
+  };
+
+  return (
+    <Body3 className={common} role="menuitem" weight="semibold" onClick={handleMenuItemClick}>
+      {icon && <Icon name={icon} size={16} />}
+      {children}
+    </Body3>
+  );
+}

--- a/src/shared/ui/Header/MenuTrigger.tsx
+++ b/src/shared/ui/Header/MenuTrigger.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import { useMenuCtx } from './useMenuCtx';
+
+import { cn } from '../../lib/core';
+
+type Props = {
+  className?: string;
+  children?: React.ReactNode;
+  'aria-label'?: string;
+};
+
+export function MenuTrigger({ children, className, 'aria-label': ariaLabel = 'open-menu' }: Props) {
+  const { open, setOpen, triggerId, contentId } = useMenuCtx();
+
+  return (
+    <button
+      id={triggerId}
+      aria-haspopup="menu"
+      aria-expanded={open ? 'true' : 'false'}
+      aria-controls={contentId}
+      onClick={() => {
+        setOpen(!open);
+      }}
+      className={cn(
+        'hover:text-primary-300 inline-flex cursor-pointer items-center gap-2 rounded-md px-4 py-2 text-base font-semibold whitespace-nowrap text-neutral-500 transition-colors duration-200',
+        className
+      )}
+      aria-label={ariaLabel}
+      type="button"
+    >
+      {children}
+    </button>
+  );
+}

--- a/src/shared/ui/Header/NavigationItem.tsx
+++ b/src/shared/ui/Header/NavigationItem.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import { ReactNode } from 'react';
+
+import { cn } from '../../lib/core';
+import { Body3 } from '../Typography';
+
+type Props = {
+  href: string;
+  onClick?: () => void;
+  active?: boolean;
+  className?: string;
+  children: ReactNode;
+};
+
+export function NavigationItem({ href, onClick, active, className, children }: Props) {
+  const base =
+    'inline-flex items-center gap-2 rounded-md px-2 py-2 whitespace-nowrap transition-colors duration-200';
+  const color = active ? 'text-primary-500' : 'text-neutral-500 hover:text-primary-300';
+
+  return (
+    <a href={href} onClick={onClick} className={cn(base, color, className)}>
+      <Body3 weight="semibold">{children}</Body3>
+    </a>
+  );
+}

--- a/src/shared/ui/Header/index.ts
+++ b/src/shared/ui/Header/index.ts
@@ -1,0 +1,6 @@
+export { Header } from './Header';
+export { NavigationItem } from './NavigationItem';
+export { MenuContainer } from './MenuContext';
+export { Menu } from './Menu';
+export { MenuTrigger } from './MenuTrigger';
+export { MenuItem } from './MenuItem';

--- a/src/shared/ui/Header/menu-context.ts
+++ b/src/shared/ui/Header/menu-context.ts
@@ -1,0 +1,10 @@
+import { createContext } from 'react';
+
+export type MenuCtx = {
+  open: boolean;
+  setOpen: (v: boolean) => void;
+  triggerId: string;
+  contentId: string;
+};
+
+export const MenuContext = createContext<MenuCtx | null>(null);

--- a/src/shared/ui/Header/useClickOutside.ts
+++ b/src/shared/ui/Header/useClickOutside.ts
@@ -1,0 +1,19 @@
+import { useEffect, RefObject } from 'react';
+
+type UseClickOutsideProps<T extends HTMLElement = HTMLElement> = {
+  ref: RefObject<T | null>;
+  handler: () => void;
+  enabled?: boolean;
+};
+
+export function useClickOutside<T extends HTMLElement>({ ref, handler }: UseClickOutsideProps<T>) {
+  useEffect(() => {
+    const listener = (event: MouseEvent) => {
+      if (ref.current && !ref.current.contains(event.target as Node)) {
+        handler();
+      }
+    };
+    document.addEventListener('mousedown', listener);
+    return () => document.removeEventListener('mousedown', listener);
+  }, [ref, handler]);
+}

--- a/src/shared/ui/Header/useMenuCtx.ts
+++ b/src/shared/ui/Header/useMenuCtx.ts
@@ -1,0 +1,11 @@
+'use client';
+
+import { useContext } from 'react';
+
+import { MenuContext } from './menu-context';
+
+export function useMenuCtx() {
+  const ctx = useContext(MenuContext);
+  if (!ctx) throw new Error('MenuContext is not provided');
+  return ctx;
+}


### PR DESCRIPTION
## 🔥 연관 이슈

- close #87 

## 🚀 작업 내용
<img width="1096" height="374" alt="스크린샷 2025-10-30 오후 7 30 59" src="https://github.com/user-attachments/assets/d5deb914-5ca7-45db-bc15-e4df07d6aa61" />

- [x] Header 컴포넌트 제작 
- [x] Header 스토리북 제작 

메인 페이지에 Header에 사용될 컴포넌트 제작을 하였습니다 

## 🤔 고민했던 내용
헤더에 사용하는 `useClickOutside`를 헤더 컴포넌트 내부에 위치하게 해두었습니다
해당 훅 또한 사용되는 곳이 많을 것으로 예상되어서, 따로 컴포넌트로 분리하면 어떨지 의견 부탁드립니다!

## 💬 리뷰 중점사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 헤더 컴포넌트 추가: 고정 상단 바 레이아웃 지원
  * 네비게이션 컴포넌트 추가: 싱글 링크 및 드롭다운 메뉴 지원
  * 반응형 메뉴 시스템: 외부/내부 링크 구분, 아이콘 지원
  * 공개 API를 통한 접근성 개선: 모든 헤더/메뉴 컴포넌트 사용 가능

<!-- end of auto-generated comment: release notes by coderabbit.ai -->