### PR TITLE
[FIX] 버전업을 별도 PR을 통해 처리하도록 변경

### DIFF
--- a/.github/workflows/auto-bump-version.yaml
+++ b/.github/workflows/auto-bump-version.yaml
@@ -156,7 +156,7 @@ jobs:
 
       - name: Create branch and commit
         run: |
-          TIMESTAMP=$(date +'%Y%m%d-%H%M%S')
+          TIMESTAMP=$(date -u +'%Y%m%d-%H%M%S%N' | cut -c1-14)
           BRANCH="bump/$TIMESTAMP"
 
           git checkout -b "$BRANCH"
@@ -173,13 +173,14 @@ jobs:
           git commit -m "chore: bump version and sync shared exports"
           git push origin "$BRANCH"
 
+          echo "BRANCH_NAME=$BRANCH" >> $GITHUB_ENV
+
       - name: Create PR
         id: cpr
         uses: actions/github-script@v7
         with:
           script: |
-            const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
-            const branch = `bump/${timestamp}`;
+            const branch = process.env.BRANCH_NAME;
 
             const pr = await github.rest.pulls.create({
               owner: context.repo.owner,


### PR DESCRIPTION
## 🔥 연관 이슈

- close #84 

## 🚀 작업 내용
main 보호 규칙을 유지하면서도 자동화 기능을 안전하게 사용할 수 있도록
`머지 후 version bump 작업을 별도 브랜치에서 수행 → PR 생성 → 자동 merge방식`으로 동작하도록 수정하였습니다

## 🤔 고민했던 내용

## 💬 리뷰 중점사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 버전 자동 범프 워크플로우 재구성: 타임스탬프 분기 생성 후 커밋·푸시, 자동 PR 생성 및 자동 병합 추가
  * 워크플로우 안정성 개선: 전체 히스토리 체크아웃, 페이징 제약 제거, 패치 처리 정규화
  * 빌드·배포 흐름 유지 및 NPM 토큰 환경 변수 처리 추가; 불필요 로그 제거 및 파일 쓰기/개행 처리 안정화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->