### PR TITLE
[FEAT] merge, create PR 로직 분리

### DIFF
--- a/.github/workflows/bump-pr.yaml
+++ b/.github/workflows/bump-pr.yaml
@@ -1,0 +1,60 @@
+name: Create & Merge Bump PR
+
+on:
+  push:
+    branches:
+      - 'bump/*'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  create-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create PR
+        id: cpr
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const branch = context.ref.replace('refs/heads/', '');
+
+            const pr = await github.rest.pulls.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: 'chore: bump version & sync exports',
+              head: branch,
+              base: 'main'
+            });
+
+            core.setOutput('pr_number', pr.data.number);
+
+      - name: Auto-merge PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.pulls.merge({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: ${{ steps.cpr.outputs.pr_number }}
+            });
+
+      - name: Checkout merged main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Publish to npm
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -1,4 +1,4 @@
-name: Auto Bump Version on Merge to main
+name: Bump Version on Merge to main
 
 on:
   pull_request:
@@ -7,14 +7,12 @@ on:
 
 permissions:
   contents: write
-  pull-requests: write
 
 jobs:
   bump-version:
     if: >
       github.event.pull_request.merged == true &&
-      github.event.pull_request.base.ref == 'main' &&
-      github.actor != 'github-actions[bot]'
+      github.event.pull_request.base.ref == 'main'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout main
@@ -27,7 +25,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20'
-          registry-url: 'https://registry.npmjs.org'
 
       - name: Detect if package.json version changed in PR
         id: ver_changed
@@ -102,7 +99,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Sync exports to src/shared/index.ts
+      - name: Sync exports (inline)
         run: |
           node -e "
             const fs = require('fs');
@@ -154,7 +151,7 @@ jobs:
       - name: Build package
         run: npm run build
 
-      - name: Create branch and commit
+      - name: Create bump branch and push
         run: |
           TIMESTAMP=$(date -u +'%Y%m%d-%H%M%S%N' | cut -c1-14)
           BRANCH="bump/$TIMESTAMP"
@@ -162,7 +159,7 @@ jobs:
           git checkout -b "$BRANCH"
 
           if git diff --quiet; then
-            echo "No changes to commit."
+            echo "NO_CHANGES=true" >> $GITHUB_ENV
             exit 0
           fi
 
@@ -170,39 +167,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
           git add .
-          git commit -m "chore: bump version and sync shared exports"
+          git commit -m "chore: bump version and sync exports"
           git push origin "$BRANCH"
 
           echo "BRANCH_NAME=$BRANCH" >> $GITHUB_ENV
-
-      - name: Create PR
-        id: cpr
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const branch = process.env.BRANCH_NAME;
-
-            const pr = await github.rest.pulls.create({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              title: 'chore: bump version & sync exports',
-              head: branch,
-              base: 'main'
-            });
-
-            core.setOutput('pr_number', pr.data.number);
-
-      - name: Auto-merge PR
-        uses: actions/github-script@v7
-        with:
-          script: |
-            await github.rest.pulls.merge({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: ${{ steps.cpr.outputs.pr_number }}
-            });
-
-      - name: Publish to npm
-        run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## 🔥 연관 이슈

- close #84

## 🚀 작업 내용
PR 생성은 PR 이벤트 속 workflow가 아니라 push 이벤트에서만 허용된다고 해서
pr merge 및 브랜치 생성 로직과 pr생성로직을 분리하였습니다 



## 🤔 고민했던 내용

## 💬 리뷰 중점사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * 버전 범프 및 npm 퍼블리싱 프로세스 자동화 개선
  * CI/CD 워크플로우 최적화로 패키지 릴리스 절차 간소화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->