### PR TITLE
[FIX] Drawer 각 자식에게 Key 지정

### DIFF
--- a/src/shared/ui/Drawer/Drawer.tsx
+++ b/src/shared/ui/Drawer/Drawer.tsx
@@ -31,6 +31,7 @@ export function Drawer({ isOpen, onClose, children }: Props) {
   return (
     <Portal isOpen={isOpen}>
       <motion.div
+        key="drawer-backdrop"
         onClick={onClose}
         className="fixed inset-0 bg-black/50"
         initial={FADE_IN_ANIMATION.initial}
@@ -39,6 +40,7 @@ export function Drawer({ isOpen, onClose, children }: Props) {
       />
       <div className="fixed top-0 right-0 z-50 h-full">
         <motion.div
+          key="drawer-panel"
           className="h-full bg-white shadow-lg"
           initial={SLIDE_IN_ANIMATION.initial}
           animate={SLIDE_IN_ANIMATION.animate}


### PR DESCRIPTION
## 🔥 연관 이슈

- close #112 

## 🚀 작업 내용
Framer Motion에서 motion 요소가 내부적으로 key로 관리하도록 
Drawer의 배경과 패널 각각에 고유 key를 지정했습니다.

## 🤔 고민했던 내용

## 💬 리뷰 중점사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Drawer 컴포넌트의 렌더링 안정성을 개선했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->