### PR TITLE
[FIX] 레이아웃 겹침 문제 수정 

### DIFF
--- a/src/shared/ui/Drawer/Drawer.tsx
+++ b/src/shared/ui/Drawer/Drawer.tsx
@@ -33,7 +33,7 @@ export function Drawer({ isOpen, onClose, children }: Props) {
       <motion.div
         key="drawer-backdrop"
         onClick={onClose}
-        className="fixed inset-0 bg-black/50"
+        className="fixed inset-0 z-50 bg-black/50"
         initial={FADE_IN_ANIMATION.initial}
         animate={FADE_IN_ANIMATION.animate}
         exit={FADE_IN_ANIMATION.exit}

--- a/src/shared/ui/Header/Header.tsx
+++ b/src/shared/ui/Header/Header.tsx
@@ -13,7 +13,7 @@ export function Header({ children, className }: Props) {
   return (
     <header
       className={cn(
-        'fixed top-0 left-0 z-10 w-full border-b border-gray-200 bg-white px-6 md:z-20',
+        'fixed top-0 left-0 z-10 w-full border-b border-gray-200 bg-white px-6',
         className
       )}
     >

--- a/src/shared/ui/Modal/Modal.tsx
+++ b/src/shared/ui/Modal/Modal.tsx
@@ -46,7 +46,7 @@ export function Modal({ isOpen, closeModal, children, className }: Props) {
         animate={MODAL_MOTION.animate}
         exit={MODAL_MOTION.exit}
         transition={MODAL_MOTION.transition}
-        className={cn('fixed inset-0 z-30 flex w-full items-center justify-center', className)}
+        className={cn('fixed inset-0 z-50 flex w-full items-center justify-center', className)}
       >
         <div className="absolute inset-0 bg-black/50" onClick={handleOutsideClick} />
         <ModalContent>{children}</ModalContent>
@@ -62,7 +62,7 @@ export function ModalContent({ children }: { children: React.ReactNode }) {
       aria-modal="true"
       justifyContent="center"
       alignItems="center"
-      className="relative z-40 rounded-lg bg-white p-6"
+      className="relative z-50 rounded-lg bg-white p-6"
     >
       {children}
     </Flex>


### PR DESCRIPTION
## 🔥 연관 이슈

- close #114

## 🚀 작업 내용
Drawer 배경에 z-index를 지정하여 레이아웃 겹침 문제 수정했습니다 

## 🤔 고민했던 내용

## 💬 리뷰 중점사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 모달, 드로어 및 헤더 컴포넌트의 레이어링 순서를 조정하여 UI 요소의 올바른 표시 순서를 보장합니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->