### PR TITLE
[REFACTOR] Modal컴포넌트 closeOnOutsideClick prop 추가

### DIFF
--- a/src/shared/ui/Modal/Modal.stories.tsx
+++ b/src/shared/ui/Modal/Modal.stories.tsx
@@ -30,6 +30,7 @@ export const Basic: StoryObj<typeof Modal> = {
   },
   args: {
     isOpen: false,
+    closeOnOutsideClick: true,
   },
   render: (args) => {
     const [isOpen, setIsOpen] = useState(args.isOpen);

--- a/src/shared/ui/Modal/Modal.tsx
+++ b/src/shared/ui/Modal/Modal.tsx
@@ -20,6 +20,11 @@ type Props = {
    */
   children: ReactNode;
   /**
+   * Whether clicking outside the modal closes it.
+   * @default true
+   */
+  closeOnOutsideClick?: boolean;
+  /**
    * Additional classes to apply to the modal.
    */
   className?: string;
@@ -32,9 +37,20 @@ const MODAL_MOTION = {
   transition: { duration: 0.3 },
 } as const;
 
-export function Modal({ isOpen, closeModal, children, className }: Props) {
+export function Modal({
+  isOpen,
+  closeModal,
+  children,
+  closeOnOutsideClick = true,
+  className,
+}: Props) {
   const handleOutsideClick = (e: React.MouseEvent) => {
-    if (e.target instanceof HTMLElement && e.target === e.currentTarget && closeModal) {
+    if (
+      closeOnOutsideClick &&
+      e.target instanceof HTMLElement &&
+      e.target === e.currentTarget &&
+      closeModal
+    ) {
       closeModal();
     }
   };


### PR DESCRIPTION
## 🔥 연관 이슈

- close #128 

## 🚀 작업 내용
 
모달에 closeOnOutsideClick prop을 추가하였습니다 

## 🤔 고민했던 내용

게임 페이지 내 모달에서 외부 클릭 닫기 방지 기능이 필요하여 해당 프롭을 추가했습니다. 
서비스 레포에서 모달을 따로 만드는 방안도 고려했으나, 불필요한 라이브러리 의존성을 피하기 위해 기존 디자인 시스템 레포의 모달을 개선하는 방향으로 결정했습니다!

## 💬 리뷰 중점사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* Modal 컴포넌트에 외부 영역 클릭 시 모달 닫기 동작을 제어하는 새로운 설정 옵션이 추가되었습니다. 이 옵션은 기본적으로 활성화되어 있으며, 필요에 따라 비활성화할 수 있습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->